### PR TITLE
Force bold font-weight

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -22,6 +22,11 @@ function setPageBackgroundColor() {
     let pList;
     let option1 = document.getElementsByTagName("p");
     let option2 = document.getElementsByTagName("font");
+
+    var style = document.createElement("style");
+    style.textContent = "b { font-weight: bold; !important }";
+    document.head.appendChild(style);
+
     if (option1.length > option2.length) {
       pList = option1;
     } else {


### PR DESCRIPTION
Some sites reset the font-weight of bold tags making this extension do nothing visually, this forces it back to being bold. I tested it on Reddit and the NYT which now work.