### PR TITLE
feat: keep original element styles while changing to bionic mode

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -17,33 +17,41 @@ changeColor.addEventListener("click", async () => {
 
 // The body of this function will be executed as a content script inside the current page
 function convertToReadbaleText() {
-  chrome.storage.sync.get("color", async ({ color }) => {
-    
-    // setting global styles
-    var style = document.createElement("style");
-    style.textContent = "b { font-weight: bold !important; }";
-    document.head.appendChild(style);
-	
-	let tags = ["p", "font", "span"];
-	
-	tags.forEach((element) => {
-		pList = document.getElementsByTagName(element);
-		// making half of the letters in a word bold
-		for (let sentence of pList) {
-		  const sentenceText = sentence.innerText;
-		  const textArr = sentenceText.split(" ");
-		  const textArrTransformed = textArr.map((word) => {
-			const length = word.length;
-			const midPoint = Math.round(length / 2);
-			const firstHalf = word.slice(0, midPoint);
-			const secondHalf = word.slice(midPoint);
-			const htmlWord = `<b>${firstHalf}</b>${secondHalf}`;
-			return htmlWord;
-		  });
-		  console.log();
-		  sentence.innerHTML = textArrTransformed.join(" ");
-		}
-	});
+	// making half of the letters in a word bold
+	function highlightText(sentenceText) {
+    return sentenceText
+      .split(' ')
+      .map((word) => {
+        const length = word.length
+        const midPoint = Math.round(length / 2)
+        const firstHalf = word.slice(0, midPoint)
+        const secondHalf = word.slice(midPoint)
+        const htmlWord = `<b>${firstHalf}</b>${secondHalf}`
+        return htmlWord
+      })
+      .join(' ')
+  }
 
-  });
+	chrome.storage.sync.get('color', async ({ color }) => {
+    // setting global styles
+    var style = document.createElement('style')
+    style.textContent = 'b { font-weight: bold !important; }'
+    document.head.appendChild(style)
+
+    let tags = ['p', 'font', 'span', 'li']
+
+    const parser = new DOMParser()
+    tags.forEach((tag) => {
+      for (let element of document.getElementsByTagName(tag)) {
+        const n = parser.parseFromString(element.innerHTML, 'text/html')
+        const textArrTransformed = Array.from(n.body.childNodes).map((node) => {
+          if (node.nodeType === Node.TEXT_NODE) {
+            return highlightText(node.nodeValue)
+          }
+          return node.outerHTML
+        })
+        element.innerHTML = textArrTransformed.join(' ')
+      }
+    })
+  })
 }


### PR DESCRIPTION
Only highlight textNodes so that it won't break elements' original styles

<img width="760" alt="image" src="https://user-images.githubusercontent.com/7059872/169680743-8dd2c4ee-a371-4f6e-babc-f5ee90ffe88c.png">
