### PR TITLE
Add list of blacklisted parent containers

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -22,6 +22,19 @@ function highlightText(sentenceText) {
     .join(' ');
 }
 
+/*
+Recursively check if a node's parent is contained in a list of tags
+ */
+function parentIsBlacklisted(node, blacklist) {
+    if (node.parentElement?.tagName === undefined) {
+        return false;
+    }
+    if (blacklist.indexOf(node.parentElement.tagName) >= 0) {
+        return true;
+    }
+    return parentIsBlacklisted(node.parentElement, blacklist);
+}
+
 function main() {
   // check if we have already highlighted the text
   const boldedElements = document.getElementsByTagName('br-bold');
@@ -39,17 +52,22 @@ function main() {
   style.textContent = '.br-bold br-bold { font-weight: bold !important; display: inline; line-height: var(--br-line-height,initial); }';
   document.head.appendChild(style);
 
-  const tags = ['p', 'font', 'span', 'li'];
+  const scannedTags = ['p', 'font', 'span', 'li'];
+  // List of tags in which if any of the above are contained, will be ignored and not highlighted
+  const blacklistParentTags = ['CODE'];
 
   const parser = new DOMParser();
-  tags.forEach((tag) => {
+  scannedTags.forEach((tag) => {
     for (const element of document.getElementsByTagName(tag)) {
+      if(parentIsBlacklisted(element, blacklistParentTags)) {
+          continue;
+      }
       const n = parser.parseFromString(element.innerHTML, 'text/html');
       const textArrTransformed = Array.from(n.body.childNodes).map((node) => {
-        if (node.nodeType === Node.TEXT_NODE) {
-          return highlightText(node.nodeValue);
-        }
-        return node.outerHTML;
+          if (node.nodeType === Node.TEXT_NODE) {
+            return highlightText(node.nodeValue);
+          }
+          return node.outerHTML;
       });
       element.innerHTML = textArrTransformed.join(' ');
     }


### PR DESCRIPTION
I've noticed that syntax highlighted code wrapped in `<code>` tags was also being highlighted; I've added support for being able to ignore any tags, which are contained within any "blacklisted" parent tags - and blacklisted `<code>`. I've added this as I dont think code should be highlighted as if it was text, and based on the language/syntax it can actually be quite confusing to read.

Please note that the feature will look up the entire parent tree, and if a blacklisted tag is a parent at any point in the list of parents of a text node, it will abandon the text node. This is because individual `<span>`, `<p>` and other tags can be present in `<code>` tags, and there can be a few levels of nesting depending on what module a website uses for rendering/highlighting their code, but the tags are never actually text.