### PR TITLE
Improves word midpoint selection algorithm

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -1,3 +1,11 @@
+function logn(value, base = 10) {
+    return Math.log(value) / Math.log(base);
+}
+
+function determineMidpoint(word) {
+    return Math.ceil(logn(word.length, 2));
+}
+
 // making half of the letters in a word bold
 function highlightText(sentenceText) {
   return sentenceText
@@ -11,13 +19,13 @@ function highlightText(sentenceText) {
       if (hasNumber.test(word)) {
         return word;
       }
-      const { length } = word;
-      let midPoint = 1;
-      if (length > 3) midPoint = Math.round(length / 2);
+
+      const midPoint = determineMidpoint(word);
+
       const firstHalf = word.slice(0, midPoint);
       const secondHalf = word.slice(midPoint);
-      const htmlWord = `<br-bold>${firstHalf}</br-bold>${secondHalf}`;
-      return htmlWord;
+      
+      return `<br-bold>${firstHalf}</br-bold>${secondHalf}`;
     })
     .join(' ');
 }


### PR DESCRIPTION
Improves word midpoint selection algorithm to account for other languages like German, which sees unusually long words where we do not necessarily want to actually select half of the word. 

The chosen algorithm is as advised is ceil(log2(word.length)) which scales much better with long words but will, for the most part, mimic the same midpoints-ish as previously. 

In following PRs we can create additional 'fixation' algorithms, e.g. we would ceil or floor depending on low or strong fixation, or a completely different approach could be taken where words are categorised based on how long they are (short, medium, long) and individual cutoff point algorithms are chosen per bucket. 