### PR TITLE
feat: change word detection to use regex

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -1,16 +1,7 @@
 // making half of the letters in a word bold
 function highlightText(sentenceText) {
   return sentenceText
-    .split(' ')
-    .map((word) => {
-      // special case - hyphenated compound word, e.g. video-game
-      if (word.includes('-')) {
-        return word.split('-').map((component) => highlightText(component)).join('-');
-      }
-      const hasNumber = /\d/;
-      if (hasNumber.test(word)) {
-        return word;
-      }
+    .replace(/\p{L}+/gu, (word) => {
       const { length } = word;
       let midPoint = 1;
       if (length > 3) midPoint = Math.round(length / 2);
@@ -18,8 +9,7 @@ function highlightText(sentenceText) {
       const secondHalf = word.slice(midPoint);
       const htmlWord = `<br-bold>${firstHalf}</br-bold>${secondHalf}`;
       return htmlWord;
-    })
-    .join(' ');
+    });
 }
 
 function main() {


### PR DESCRIPTION
The current method of splitting on spaces means punctuation often gets treated as part of a word:
![image](https://user-images.githubusercontent.com/34172308/169980913-d4897eef-ff9f-477d-8991-e47743115a5b.png)

We can eliminate this problem by using a word regex instead. This also eliminates the need for extra handling of hyphenated words and numbers.
![image](https://user-images.githubusercontent.com/34172308/169981551-f9a6268c-d40e-4059-a0c9-cdf0352e2681.png)

Finally, I used the newish syntax `\p{L}`, to account for non ascii characters.
It should match a letter in any script, since it's based on unicode character properties.