### PR TITLE
Fixed #73

### DIFF
--- a/src/ContentScript/index.js
+++ b/src/ContentScript/index.js
@@ -19,18 +19,18 @@ const ToggleReading = (enableReading) => {
     if (typeof enableReading === 'undefined' || enableReading === undefined) {
       for (const element of boldedElements) {
         element.classList.toggle('br-bold');
-        document.body.classList.toggle('br-bold');
       }
+      document.body.classList.toggle('br-bold');
     } else if (enableReading === false) {
       for (const element of boldedElements) {
         element.classList.remove('br-bold');
-        document.body.classList.remove('br-bold');
       }
+      document.body.classList.remove('br-bold');
     } else {
       for (const element of boldedElements) {
         element.classList.add('br-bold');
-        document.body.classList.add('br-bold');
       }
+      document.body.classList.add('br-bold');
     }
     return;
   }


### PR DESCRIPTION
I decided to investigate #73 myself and as it turns out, some times the `br-bold` class is not toggled off in `<body>` class. It turns out that in `index.js`, the body classlist toggle is put inside a for loop, and when that for loop runs an even number of times, the body tag remains untouched!

This PR provide a simple fix that should address #73. Tested with macOS Monterey, Chrome latest build. 